### PR TITLE
bootifying the tree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ env:
     matrix:
         - TEST_CMD='lein test'
         - TEST_CMD='lein bench output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set'
-        - TEST_CMD='lein bench output -d forward -- --d reverse -- -d shuffle -- -d zero'
+        - TEST_CMD='lein bench output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero'
 script: $TEST_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
-language: java
+sudo: false
+language: clojure
 
-install:
-    - mkdir -p ~/bin
-    - export PATH=~/bin:$PATH
+before_install:
     - curl -fsSLo boot https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh
-    - chmod +x ~/bin/boot
     - chmod 755 boot
 
 services:
@@ -13,7 +11,13 @@ env:
     global:
         - BOOT_JVM_OPTIONS='-server -Xmx3700m -Xms3700m'
     matrix:
-        - TEST_CMD='boot test'
-        - TEST_CMD='boot bench -a "output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set"'
-        - TEST_CMD='boot bench -a "output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero"'
+        - TEST_CMD='./boot test'
+        - TEST_CMD='./boot bench -a "output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set"'
+        - TEST_CMD='./boot bench -a "output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero"'
 script: $TEST_CMD
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.boot/cache/bin
+  - $HOME/.boot/cache/lib
+  - $HOME/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-language: clojure
+language: java
 
-before_install:
+install:
+    - mkdir -p ~/bin
+    - export PATH=~/bin:$PATH
     - curl -fsSLo boot https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh
+    - chmod +x ~/bin/boot
     - chmod 755 boot
 
 services:
@@ -10,7 +13,7 @@ env:
     global:
         - BOOT_JVM_OPTIONS='-server -Xmx3700m -Xms3700m'
     matrix:
-        - TEST_CMD='./boot test'
-        - TEST_CMD='./boot bench -a "output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set"'
-        - TEST_CMD='./boot bench -a "output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero"'
+        - TEST_CMD='boot test'
+        - TEST_CMD='boot bench -a "output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set"'
+        - TEST_CMD='boot bench -a "output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero"'
 script: $TEST_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: clojure
 services:
     - redis-server
 env:
-    - BOOT_JVM_OPTIONS='-server -Xmx3700m -Xms3700m'
     matrix:
+        - BOOT_JVM_OPTIONS='-server -Xmx3700m -Xms3700m'
         - TEST_CMD='boot test'
         - TEST_CMD='boot bench -a "output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set"'
         - TEST_CMD='boot bench -a "output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     global:
         - BOOT_JVM_OPTIONS='-server -Xmx3700m -Xms3700m'
     matrix:
-        - TEST_CMD='boot test'
-        - TEST_CMD='boot bench -a "output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set"'
-        - TEST_CMD='boot bench -a "output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero"'
+        - TEST_CMD='./boot test'
+        - TEST_CMD='./boot bench -a "output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set"'
+        - TEST_CMD='./boot bench -a "output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero"'
 script: $TEST_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: clojure
+services:
+    - redis-server
 env:
     matrix:
         - TEST_CMD='lein test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: clojure
 services:
     - redis-server
 env:
+    - BOOT_JVM_OPTIONS='-server -Xmx3700m -Xms3700m'
     matrix:
-        - TEST_CMD='lein test'
-        - TEST_CMD='lein bench output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set'
-        - TEST_CMD='lein bench output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero'
+        - TEST_CMD='boot test'
+        - TEST_CMD='boot bench -a "output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set"'
+        - TEST_CMD='boot bench -a "output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero"'
 script: $TEST_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: clojure
+
+before_install:
+    - curl -fsSLo boot https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh
+    - chmod 755 boot
+
 services:
     - redis-server
 env:
-    matrix:
+    global:
         - BOOT_JVM_OPTIONS='-server -Xmx3700m -Xms3700m'
+    matrix:
         - TEST_CMD='boot test'
         - TEST_CMD='boot bench -a "output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set"'
         - TEST_CMD='boot bench -a "output --delete-pattern forward -- --delete-pattern reverse -- --delete-pattern shuffle -- --delete-pattern zero"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: clojure
+env:
+    matrix:
+        - TEST_CMD='lein test'
+        - TEST_CMD='lein bench output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set'
+        - TEST_CMD='lein bench output -d forward -- --d reverse -- -d shuffle -- -d zero'
+script: $TEST_CMD

--- a/build.boot
+++ b/build.boot
@@ -28,7 +28,11 @@
 
   (let [bench-it (resolve 'hitchhiker.bench/-main)]
     (apply bench-it (clojure.string/split args #" "))))
-  
+
+(deftask test []
+  (set-env! :source-paths #(conj % "test"))
+  (bt/test))
+
 (task-options!
   pom {:project     'hitchhiker-tree
        :version     +version+

--- a/build.boot
+++ b/build.boot
@@ -1,0 +1,39 @@
+(def +version+ "0.1.0-SNAPSHOT")
+
+(set-env!
+  :source-paths #{"src"}
+  :dependencies '[[org.clojure/clojure      "1.8.0"]
+                  [org.clojure/core.memoize "0.5.8" ]
+                  [com.taoensso/carmine "2.12.2"]
+                  [org.clojure/core.rrb-vector "0.0.11"]
+
+                  [criterium "0.4.4"                          :scope "provided"]
+                  [org.clojure/tools.cli "0.3.3"              :scope "provided"]
+                  [org.clojure/test.check "0.9.0"             :scope "provided"]
+                  [com.infolace/excel-templates "0.3.3"       :scope "provided"]
+
+                  ;; boot
+                  [boot/core                "2.5.1"           :scope "provided"]
+                  [adzerk/bootlaces         "0.1.13"          :scope "test"]
+                  [adzerk/boot-test         "1.0.6"           :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[adzerk.boot-test :as bt])
+
+(bootlaces! +version+)
+
+(deftask bench [a args ARGS str "bench arguments"]
+  (set-env! :source-paths #(conj % "env/profiling"))
+  (require 'hitchhiker.bench)
+
+  (let [bench-it (resolve 'hitchhiker.bench/-main)]
+    (apply bench-it (clojure.string/split args #" "))))
+  
+(task-options!
+  pom {:project     'hitchhiker-tree
+       :version     +version+
+       :description "A Hitchhiker Tree Library"
+       :url         "https://github.com/dgrnbrg/hitchhiker-tree"
+       :scm         {:url "https://github.com/dgrnbrg/hitchhiker-tree"}
+       :license     {"Eclipse Public License"
+                     "http://www.eclipse.org/legal/epl-v10.html"}})

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [com.taoensso/carmine "2.12.2"]
                  [org.clojure/core.rrb-vector "0.0.11"]]
   :aliases {"bench" ["with-profile" "profiling" "run" "-m" "hitchhiker.bench"]}
+  :jvm-opts ["-server" "-Xmx3700m" "-Xms3700m"]
   :profiles {:test
              {:dependencies [[org.clojure/test.check "0.9.0"]]}
              :profiling


### PR DESCRIPTION
bench is not exactly a "regular" build task, but nothing `boot` can't handle :)

### Building a Jar

```bash
[tolitius:..playground/hitchhiker-tree]$ boot pom jar                                                                                     
Writing pom.xml and pom.properties...
Writing hitchhiker-tree-0.1.0-SNAPSHOT.jar...
```

### Benching

```$ boot bench --args "perf_diff_experiment -b 10 -- -b 42"```

#### What's with "--args"?

notice `--args`. there are multiple ways to pass runtime args, but one thing to note `boot` stays true to tasks whether you run them from command line, REPL, within `build.boot`, etc.. and the format is "[task options](https://github.com/boot-clj/boot/wiki/Task-Options-DSL)". Those options a types, so we can pass args as a Clojure map for example, but I did not want to change the String expectation that is already in the `bench/-main`

#### String args vs. Clojure map

In reality, `bench` could be _just a function_ that takes a Clojure map as args, and in case we do need `-main`, we can have it parse the String args. This way boot and any other Clojure function can call it directly with just a map.

```bash
[tolitius:..playground/hitchhiker-tree]$ boot bench --args "perf_diff_experiment -b 10 -- -b 42"                                           
Doing fractal__flush_1000__b_10__testing__n_100000__del_forward_in-order
Doing fractal__flush_1000__b_10__testing__n_100000__del_forward_random
Doing fractal__flush_1000__b_42__testing__n_100000__del_forward_in-order
Doing fractal__flush_1000__b_42__testing__n_100000__del_forward_random
```

#### TravisCI

It is running as:

```bash
$ export TEST_CMD='lein bench output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set'
```

Boot can too:

```bash
[tolitius:..playground/hitchhiker-tree]$ boot bench -a "output --data-structure fractal -- --data-structure b-tree -- --data-structure sorted-set"
Doing fractal__flush_1000__b_300__testing__n_100000__del_forward_in-order
Doing fractal__flush_1000__b_300__testing__n_100000__del_forward_random
Doing b-tree__flush_1000__b_300__testing__n_100000__del_forward_in-order
Doing b-tree__flush_1000__b_300__testing__n_100000__del_forward_random
Doing sorted-set__flush_1000__b_300__testing__n_100000__del_forward_in-order
Doing sorted-set__flush_1000__b_300__testing__n_100000__del_forward_random
```