### PR TITLE
add core cache as a dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/core.memoize "0.5.8"]
                  [com.taoensso/carmine "2.12.2"]
-                 [org.clojure/core.rrb-vector "0.0.11"]]
+                 [org.clojure/core.rrb-vector "0.0.11"]
+                 [org.clojure/core.cache "0.6.5"]]
   :aliases {"bench" ["with-profile" "profiling" "run" "-m" "hitchhiker.bench"]}
   :jvm-opts ["-server" "-Xmx3700m" "-Xms3700m"]
   :profiles {:test


### PR DESCRIPTION
Hi!

It looks like the project uses `clojure.core.cache` in `hitchhiker.redis`, though it doesn't appear as a dependency in the `project.clj`  The tests pass, though when I try to use hitchhiker-tree in my projects the dependency is missing.  This just adds the dep.

Thanks!

Kyle